### PR TITLE
Configuring units 

### DIFF
--- a/lib/handlebars-helpers.js
+++ b/lib/handlebars-helpers.js
@@ -3,11 +3,30 @@ var log = new Log('fuse.handlebars');
 
 var Handlebars = require('handlebars-v2.0.0.js').Handlebars;
 
-var getScope = function (unit) {
+var getScope = function (unit,configs) {
     var jsFile = fuse.getFile(unit, '', '.js');
+    var templateConfigs = configs || {};
+    var script;
+    var onRequestCb = function(){}; //Assume that onRequest function will not be defined by the user
     var viewModel = {};
     if (jsFile.isExists()) {
-        viewModel = require(jsFile.getPath()).onRequest();
+        script = require(jsFile.getPath());
+        //Eagerly make the viewModel the template configs
+        viewModel = templateConfigs;
+        //Check if the unit author has specified an onRequest
+        //callback
+        if(script.hasOwnProperty('onRequest')){
+            onRequestCb = script.onRequest;
+            //If the onRequestCb does not return anything we do not
+            //provide the templateConfigs as the empty object may be 
+            //intentional   
+            viewModel = onRequestCb(templateConfigs)||{};
+        }
+    }
+    else{
+        //If there is no script then the view should get the configurations
+        //passed in the unit call
+        viewModel = templateConfigs;
     }
     viewModel.app = {
         url: '/' + fuseState.appName
@@ -90,9 +109,10 @@ Handlebars.registerHelper('layout', function (layoutName) {
     }
 });
 
-Handlebars.registerHelper('unit', function (unitName) {
+Handlebars.registerHelper('unit', function (unitName,options) {
     var unitDef = fuse.getUnitDefinition(unitName);
     var baseUnit = null;
+    var templateConfigs = options.hash || {};
     for (var i = 0; i < unitDef.zones.length; i++) {
         var zone = unitDef.zones[i];
         if (zone.name == 'main') {
@@ -113,7 +133,7 @@ Handlebars.registerHelper('unit', function (unitName) {
     fuseState.currentZone.push('main');
     var template = fuse.getFile(baseUnit, '', '.hbs');
     log.info('[' + requestId + '] including "' + baseUnit + '"');
-    var result = new Handlebars.SafeString(Handlebars.compileFile(template)(getScope(baseUnit)));
+    var result = new Handlebars.SafeString(Handlebars.compileFile(template)(getScope(baseUnit,templateConfigs)));
     fuseState.currentZone.pop();
     return result;
 });


### PR DESCRIPTION
This PR adds support for configuring a unit by passing a set of key value pairs.
# Example

``` handlebars
 {{unit "test-unit" title="hello"}}
```
# Behaviour

The provided key value pairs are passed to the onRequest callback function found in the component.js file.If the component.js file is not provided or if the unit author has not specified the component.js then the configs will be passed to the view directly (component.hbs). 
