### PR TITLE
Child units that extend from a parent recieve the parent's data

### DIFF
--- a/lib/handlebars-helpers.js
+++ b/lib/handlebars-helpers.js
@@ -50,6 +50,8 @@ Handlebars.innerZonesFromUnit = null;
 
 Handlebars.registerHelper('defineZone', function (zoneName, zoneContent) {
     var result = '';
+    //Child units will need to inherit the parent data context
+    var parentData = (zoneContent.data)? zoneContent.data.root:{};
     var zone = Handlebars.Utils.escapeExpression(zoneName);
     fuseState.currentZone.push(zone);
     var unitsToRender = fuseState.zones[zone] || [];
@@ -68,7 +70,7 @@ Handlebars.registerHelper('defineZone', function (zoneName, zoneContent) {
         if (Handlebars.innerZonesFromUnit == null || Handlebars.innerZonesFromUnit.unitName == unit.unitName) {
             var template = fuse.getFile(unit.originUnitName || unit.unitName, '', '.hbs');
             log.debug('[' + requestId + '] for zone "' + zone + '" including template :"' + template.getPath() + '"');
-            result += Handlebars.compileFile(template)(getScope(unit.unitName));
+            result += Handlebars.compileFile(template)(getScope(unit.unitName,parentData||{}));
         }
     }
 


### PR DESCRIPTION
This PR allows child units that **extend** from a parent unit to inherit the data context of the parent.

_Note_ : Need to discuss possibility of name spacing the data context
